### PR TITLE
Add Airtable to Google Sheets Sync template

### DIFF
--- a/Data_Analytics/Airtable_to_Google_Sheets_Sync.json
+++ b/Data_Analytics/Airtable_to_Google_Sheets_Sync.json
@@ -1,0 +1,44 @@
+{
+  "name": "Airtable to Google Sheets Sync",
+  "nodes": [
+    {
+      "parameters": {"rule": {"interval": [{"triggerAtHour": 9}]}},
+      "id": "sched-trigger",
+      "name": "Schedule",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.1,
+      "position": [250, 300]
+    },
+    {
+      "parameters": {
+        "operation": "list",
+        "baseId": {"mode": "id", "value": "YOUR_BASE_ID"},
+        "table": {"mode": "list", "value": "YOUR_TABLE"}
+      },
+      "id": "airtable-list",
+      "name": "Airtable List",
+      "type": "n8n-nodes-base.airtable",
+      "typeVersion": 2,
+      "position": [450, 300]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "sheetId": {"mode": "url", "value": "YOUR_SHEET_URL"},
+        "range": "A1"
+      },
+      "id": "gsheets-append",
+      "name": "Google Sheets Append",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.2,
+      "position": [650, 300]
+    }
+  ],
+  "connections": {
+    "Schedule": {"main": [[{"node": "Airtable List", "type": "main", "index": 0}]]},
+    "Airtable List": {"main": [[{"node": "Google Sheets Append", "type": "main", "index": 0}]]}
+  },
+  "settings": {"executionOrder": "v1", "timezone": "Asia/Shanghai"},
+  "tags": ["airtable", "google-sheets", "sync"],
+  "meta": {"templateCredsSetup": false}
+}

--- a/Data_Analytics/README.md
+++ b/Data_Analytics/README.md
@@ -1,3 +1,4 @@
 # Data_Analytics Templates
 
 - **competitor_price_scraper.json** – Uses Anthropic Claude, OpenAI Embeddings, Supabase Vector
+- **Airtable_to_Google_Sheets_Sync.json** – Syncs Airtable records to Google Sheets daily. Uses Schedule Trigger + Airtable + Google Sheets nodes.


### PR DESCRIPTION
## Template: Airtable to Google Sheets Sync

**Category:** Data_Analytics

**What it does:** Automatically syncs records from an Airtable base to Google Sheets on a daily schedule (9 AM). Simple, production-ready workflow.

**Tech:** Schedule Trigger + Airtable + Google Sheets (no external AI required)

**Setup:**
1. Add Airtable credentials (Base ID + API Key)
2. Add Google Sheets OAuth2 credentials
3. Update Sheet URL in Google Sheets node
4. Activate

**Author:** Wang Pingzhe (王平政哲) - n8n automation specialist

---
*Submitted via GitHub PR automation - Round 92 learning state*